### PR TITLE
Update link to medium post

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -13,7 +13,7 @@ We welcome and value your contributions to any and all of the repositories in th
 # Links and Resources
 - [Ruby/Rails Modularity Slack Server invite link](https://join.slack.com/t/rubymod/shared_invite/zt-23z6gq875-tjoDBhcjmvtSNzl7h_GcWg)
 - [RailsConf Talk – Laying the Cultural and Technical Foundation for Big Rails](https://www.youtube.com/watch?v=J9S0qiGkAQY&t=384s)
-- [Gusto Blog Post – Laying the Cultural and Technical Foundation for Big Rails](https://engineering.gusto.com/laying-the-cultural-and-technical-foundation-for-big-rails/)
+- [Gusto Blog Post – Laying the Cultural and Technical Foundation for Big Rails](https://engineering.gusto.com/laying-the-cultural-and-technical-foundation-for-big-rails-6b5ab78349ed)
 - [Gusto Blog Post – A How-to Guide to Ruby Packs, Gusto’s Gem Ecosystem for Modularizing Ruby Applications](https://medium.com/gusto-engineering/a-how-to-guide-to-ruby-packs-gustos-gem-ecosystem-for-modularizing-ruby-applications-e236126b8c2c)
 - [Gusto Modularization Toolchain (describes some of the tools in this org and how they relate)](https://drive.google.com/file/d/11uhLDCN6OxdHq8eIlgAsj8FjmfZ0keTO/view?usp=sharing):
 


### PR DESCRIPTION
## The problem

The README points at a legacy version of the link to the "Laying the Cultural and Technical Foundation for Big Rails" medium post.

## The solution

Amend the link.