### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rubyatscale/ruby-at-scale


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file assigning all files in the repository to `@rubyatscale/ruby-at-scale`.